### PR TITLE
Introduce Roms Manager component powered by FileSystemSelectorComponent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Makefile
 
 .idea/
 *.iml
+*.txt.user*

--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/RatingComponent.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/ScraperSearchComponent.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/TextListComponent.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/components/FileSystemSelectorComponent.h
 
     # Guis
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiFastSelect.h
@@ -28,6 +29,7 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScraperMulti.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScraperStart.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiUpdate.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomsManager.h
 
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.h
@@ -69,6 +71,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/AsyncReqComponent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/RatingComponent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/ScraperSearchComponent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/components/FileSystemSelectorComponent.cpp
 
     # Guis
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiFastSelect.cpp
@@ -80,6 +83,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScraperMulti.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScraperStart.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiUpdate.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomsManager.cpp
 
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.cpp

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -47,8 +47,11 @@ public:
 	std::vector<FileData*> getFilesRecursive(unsigned int typeMask) const;
 	std::vector<FileData*> getFavoritesRecursive(unsigned int typeMask) const;
 
+	void changePath(const boost::filesystem::path& path);
 	void addChild(FileData* file); // Error if mType != FOLDER
 	void removeChild(FileData* file); //Error if mType != FOLDER
+	void clear();
+	void lazyPopulate(const std::vector<std::string>& searchExtensions = std::vector<std::string>(), SystemData* systemData = nullptr);
 
 	// Returns our best guess at the "real" name for this file (will strip parenthesis and attempt to perform MAME name translation)
 	std::string getCleanName() const;
@@ -66,6 +69,9 @@ public:
 
 	void sort(ComparisonFunction& comparator, bool ascending = true);
 	void sort(const SortType& type);
+
+	static void populateFolder(FileData* folder, const std::vector<std::string>& searchExtensions = std::vector<std::string>(), SystemData* systemData = nullptr);
+	static void populateRecursiveFolder(FileData* folder, const std::vector<std::string>& searchExtensions = std::vector<std::string>(), SystemData* systemData = nullptr);
 
 	MetaDataList metadata;
 

--- a/es-app/src/components/FileSystemSelectorComponent.cpp
+++ b/es-app/src/components/FileSystemSelectorComponent.cpp
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2015 Filipe Azevedo <pasnox@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+*/
+#include "FileSystemSelectorComponent.h"
+#include "Renderer.h"
+#include "Log.h"
+
+#define DEFAULT_FONT Font::get(FONT_SIZE_MEDIUM)
+#define DEFAULT_COLOR 0x777777FF
+#define DEFAULT_DISABLED_COLOR 0xBBBBBBFF
+
+using namespace Eigen;
+namespace fs = boost::filesystem;
+typedef FileSystemSelectorComponent fssc;
+typedef fssc::FileEntry fe;
+
+struct ModePredicter : public std::unary_function<const fe*, bool>
+{
+	ModePredicter(fssc::Mode m) : mode(m) {
+	}
+
+	bool operator()(const fe* entry) {
+		switch (mode) {
+			case fssc::FilesShowFolders:
+			case fssc::FoldersShowFiles:
+				return (entry->type & fssc::FileInternal) || (entry->type & fssc::FolderInternal);
+
+			case fssc::FilesHideFolders:
+				return (entry->type & fssc::FileInternal);
+
+			case fssc::FoldersHideFiles:
+				return (entry->type & fssc::FolderInternal);
+		}
+
+		return false;
+	}
+
+	bool operator()(const fe& entry) {
+		return operator()(&entry);
+	}
+
+private:
+	fssc::Mode mode;
+};
+
+bool sortPredicter(const fe& lhs, const fe& rhs) {
+	const std::string leftName = strToUpper(lhs.filePath.filename().string());
+	const std::string rightName = strToUpper(rhs.filePath.filename().string());
+
+	if (((lhs.type & fssc::FolderInternal) && (rhs.type & fssc::FolderInternal))
+			|| ((lhs.type & fssc::FileInternal) && (rhs.type & fssc::FileInternal))) {
+		return leftName.compare(rightName) < 0;
+	}
+
+	return lhs.type & fssc::FolderInternal;
+}
+
+FileSystemSelectorComponent::FileSystemSelectorComponent(Window* window, fssc::Mode mode)
+	: MenuComponent(window, nullptr)
+{
+	init(mode, getHomePath());
+}
+
+FileSystemSelectorComponent::FileSystemSelectorComponent(Window* window, const fs::path& path, fssc::Mode mode)
+	: MenuComponent(window, nullptr)
+{
+	init(mode, path);
+}
+
+void FileSystemSelectorComponent::init(const fssc::Mode mode, const fs::path& path)
+{
+	m_mode = mode;
+	m_currentPathLabel = std::make_shared<TextComponent>(mWindow, std::string(), Font::get(FONT_SIZE_SMALL), 0xCC0000FF, ALIGN_CENTER);
+
+	setTitle(titleForCurrentMode().c_str());
+	if (!setCurrentPath(path)) {
+		setCurrentPath(getHomePath());
+	}
+	addChild(m_currentPathLabel.get());
+	onSizeChanged();
+}
+
+bool FileSystemSelectorComponent::input(InputConfig* config, Input input)
+{
+	const fs::path path = selectedFilePath();
+	const fe::Type type = filePathType(path);
+
+	if (config->isMappedTo("a", input) && input.value) { // cd in
+		if (!path.empty()) {
+			setCurrentPath(path);
+		}
+
+		return true;
+	}
+	else if (config->isMappedTo("b", input) && input.value) { // cd up
+		switch (m_mode) {
+			case fssc::FilesShowFolders:
+			case fssc::FoldersShowFiles:
+			case fssc::FoldersHideFiles:
+				setCurrentPath(m_currentPath.parent_path());
+				break;
+
+			case fssc::FilesHideFolders:
+				break;
+		}
+
+		return true;
+	}
+	else if (config->isMappedTo("x", input) && input.value) { // select
+		if (m_acceptCallback) {
+			switch (m_mode) {
+				case fssc::FilesHideFolders:
+				case fssc::FilesShowFolders: {
+					if (type & fssc::FileInternal) {
+						m_acceptCallback(path);
+						delete this;
+					}
+
+					break;
+				}
+
+				case fssc::FoldersHideFiles:
+				case fssc::FoldersShowFiles: {
+					if (type & fssc::FolderInternal) {
+						m_acceptCallback(path);
+						delete this;
+					}
+
+					break;
+				}
+			}
+		}
+
+		return true;
+	}
+	else if (config->isMappedTo("y", input) && input.value) { // exit
+		delete this;
+		return true;
+	}
+
+	return MenuComponent::input(config, input);
+}
+
+std::vector<HelpPrompt> FileSystemSelectorComponent::getHelpPrompts()
+{
+	auto prompts = MenuComponent::getHelpPrompts();
+
+	const fe::Type type = filePathType(selectedFilePath());
+
+	if (m_mode != fssc::FilesHideFolders) {
+		if (type & fssc::FolderInternal) {
+			prompts.push_back(HelpPrompt("a", "cd in"));
+		}
+
+		if (m_currentPath != m_currentPath.root_path()) {
+			prompts.push_back(HelpPrompt("b", "cd up"));
+		}
+	}
+
+	prompts.push_back(HelpPrompt("y", "cancel"));
+
+	switch (m_mode) {
+		case fssc::FilesShowFolders: {
+			if (type & fssc::FileInternal) {
+				prompts.push_back(HelpPrompt("x", "select"));
+			}
+
+			break;
+		}
+
+		case fssc::FoldersShowFiles: {
+			if (type & fssc::FolderInternal) {
+				prompts.push_back(HelpPrompt("x", "select"));
+			}
+
+			break;
+		}
+
+		case fssc::FoldersHideFiles: {
+			if (type & fssc::FolderInternal) {
+				prompts.push_back(HelpPrompt("x", "select"));
+			}
+
+			break;
+		}
+
+		case fssc::FilesHideFolders: {
+			if (type & fssc::FileInternal) {
+				prompts.push_back(HelpPrompt("x", "select"));
+			}
+
+			break;
+		}
+	}
+
+	return prompts;
+}
+
+void FileSystemSelectorComponent::onSizeChanged()
+{
+	MenuComponent::onSizeChanged();
+	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
+	m_currentPathLabel->setSize(mSize.x(), 0);
+	m_currentPathLabel->setPosition(0, mSize.y() - m_currentPathLabel->getSize().y());
+}
+
+fs::path FileSystemSelectorComponent::currentPath() const
+{
+	return m_currentPath;
+}
+
+bool FileSystemSelectorComponent::setCurrentPath(const fs::path& currentPath)
+{
+	fs::path path = currentPath;
+
+	if (!fs::is_directory(path)) {
+		path = path.parent_path();
+	}
+
+	if (!fs::exists(path) || path.empty() || m_currentPath == path) {
+		return false;
+	}
+
+	m_currentPath = path;
+
+	clear();
+	populate(m_currentPath);
+
+	const std::vector<const fe*> entries = entriesForCurrentMode();
+
+	for (auto ientry = entries.cbegin(), end = entries.cend(); ientry != end; ++ientry) {
+		const fe* entry = (*ientry);
+		ComponentListRow row(entry->filePath.string());
+		unsigned int color = DEFAULT_DISABLED_COLOR;
+		
+		// A folder
+		if (entry->type & fssc::FolderInternal) {
+			// We want a folder
+			if (m_mode & fssc::FolderInternal) {
+				color = DEFAULT_COLOR;
+			}
+		}
+		// A file
+		else if (entry->type & fssc::FileInternal) {
+			// We want a file
+			if (m_mode & fssc::FileInternal) {
+				color = DEFAULT_COLOR;
+			}
+		}
+		
+		row.addElement(std::make_shared<TextComponent>(mWindow, entry->filePath.filename().string(), DEFAULT_FONT, color), true);
+		addRow(row, false, std::next(ientry) == entries.cend());
+	}
+
+	m_currentPathLabel->setText(m_currentPath.string());
+	setSize(Renderer::getScreenWidth() * 0.95f, Renderer::getScreenHeight() * 0.747f);
+	updateHelpPrompts();
+	return true;
+}
+
+std::vector<std::string> FileSystemSelectorComponent::filters() const
+{
+	return m_filters;
+}
+
+void FileSystemSelectorComponent::setFilters(const std::vector<std::string>& filters)
+{
+	m_filters = filters;
+}
+
+fs::path FileSystemSelectorComponent::selectedFilePath() const
+{
+	ComponentList *list = getList();
+	return list->isEmpty() ? fs::path() : list->getSelectedName();
+}
+
+void FileSystemSelectorComponent::setSelectedFilePath(const fs::path& filePath)
+{
+	getList()->setSelectedName(filePath.string());
+}
+
+void FileSystemSelectorComponent::setAcceptCallback(const std::function<void (const fs::path&)>& callback)
+{
+	m_acceptCallback = callback;
+}
+
+void FileSystemSelectorComponent::setCancelCallback(const std::function<void ()>& callback)
+{
+	m_cancelCallback = callback;
+}
+
+std::string FileSystemSelectorComponent::titleForCurrentMode() const
+{
+	if (m_mode & fssc::FileInternal) {
+		return std::string("Select a file");
+	}
+	else if (m_mode & fssc::FolderInternal) {
+		return std::string("Select a folder");
+	}
+
+	return std::string("Select something");
+}
+
+fe::Type FileSystemSelectorComponent::filePathType(const fs::path& filePath) const
+{
+	if (!filePath.empty()) {
+		switch (fs::status(filePath).type()) {
+			case fs::regular_file:
+				return fe::File;
+
+			case fs::directory_file:
+				return fe::Folder;
+
+			case fs::symlink_file:
+				return fs::is_directory(filePath) ? fe::FolderSymLink : fe::FileSymLink;
+		}
+	}
+
+	return fe::InvalidType;
+}
+
+void FileSystemSelectorComponent::populate(const fs::path& path)
+{
+	if (m_entries.find(path) != m_entries.cend()) {
+		return;
+	}
+
+	if (!fs::is_directory(path)) {
+		LOG(LogWarning) << "Error - folder with path \"" << path.string() << "\" is not a directory!";
+		return;
+	}
+
+	//make sure that this isn't a symlink to a thing we already have
+	/*if (fs::is_symlink(path)) {
+		//if this symlink resolves to somewhere that's at the beginning of our path, it's gonna recurse
+		if(folderStr.find(fs::canonical(folderPath).generic_string()) == 0)
+		{
+			LOG(LogWarning) << "Skipping infinitely recursive symlink \"" << folderPath << "\"";
+			return;
+		}
+	}*/
+
+	try {
+		for (fs::directory_iterator dir(path), end; dir != end; ++dir) {
+			const fs::path filePath = (*dir).path();
+
+			// Don't show entries without extensions
+			/*if (!filePath.has_stem()) {
+				continue;
+			}*/
+
+			// don't show hidden entries
+			if (filePath.filename().string().compare(0, 1, ".") == 0) {
+				continue;
+			}
+
+			if (!m_filters.empty()) {
+				const std::string extension = filePath.extension().string();
+
+				if (std::find(m_filters.begin(), m_filters.end(), extension) == m_filters.end()) {
+					continue;
+				}
+			}
+
+			FileEntry entry;
+			entry.type = filePathType(filePath);
+			entry.filePath = filePath;
+			m_entries[path].push_back(entry);
+
+			/*if (entry.type && fssc::FolderInternal) {
+				populate(filePath);
+			}*/
+		}
+
+		std::vector<fe>& entries = m_entries[path];
+		std::stable_sort(entries.begin(), entries.end(), sortPredicter);
+	}
+	catch (...) {
+	}
+}
+
+std::vector<const fe*> FileSystemSelectorComponent::entriesForCurrentMode() const
+{
+	auto it = m_entries.find(m_currentPath);
+
+	if (it == m_entries.cend()) {
+		return std::vector<const fe*>();
+	}
+
+	const std::vector<fe>& entries = (*it).second;
+	std::vector<const fe*> matches;
+	ModePredicter modePredicter(m_mode);
+
+	matches.reserve(entries.size());
+
+	for (auto pit = entries.cbegin(), end = entries.cend(); pit != end; ++pit) {
+		const fe* entry = &(*pit);
+
+		if (modePredicter(entry)) {
+			matches.push_back(entry);
+		}
+	}
+
+	return matches;
+}

--- a/es-app/src/components/FileSystemSelectorComponent.h
+++ b/es-app/src/components/FileSystemSelectorComponent.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2015 Filipe Azevedo <pasnox@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+*/
+#pragma once
+
+#include "components/MenuComponent.h"
+
+#include <boost/filesystem/path.hpp>
+
+/*
+ * Lazy loaded file system selector component
+ * */
+class FileSystemSelectorComponent : public MenuComponent
+{
+private:
+	enum InternalType {
+		InvalidInternal = 0x0,
+		FileInternal = 0x1,
+		FolderInternal = 0x2,
+		SymLinkInternal = 0x4,
+		ShowInternal = 0x8,
+		HideInternal = 0x10
+	};
+
+public:
+	enum Mode {
+		FilesShowFolders = FileInternal | ShowInternal,
+		FilesHideFolders = FileInternal | HideInternal,
+		FoldersShowFiles = FolderInternal | ShowInternal,
+		FoldersHideFiles = FolderInternal | HideInternal
+	};
+
+	struct FileEntry {
+		enum Type {
+			InvalidType = InvalidInternal,
+			File = FileInternal,
+			FileSymLink = FileInternal | SymLinkInternal,
+			Folder = FolderInternal,
+			FolderSymLink = FolderInternal | SymLinkInternal
+		};
+
+		Type type;
+		boost::filesystem::path filePath;
+	};
+
+	FileSystemSelectorComponent(Window* window, const FileSystemSelectorComponent::Mode mode = FileSystemSelectorComponent::FilesShowFolders);
+	FileSystemSelectorComponent(Window* window, const boost::filesystem::path& path, const FileSystemSelectorComponent::Mode mode = FileSystemSelectorComponent::FilesShowFolders);
+
+	bool input(InputConfig* config, Input input) override;
+	std::vector<HelpPrompt> getHelpPrompts() override;
+	void onSizeChanged() override;
+
+	boost::filesystem::path currentPath() const;
+	bool setCurrentPath(const boost::filesystem::path& currentPath);
+
+	std::vector<std::string> filters() const;
+	void setFilters(const std::vector<std::string>& filters);
+
+	boost::filesystem::path selectedFilePath() const;
+	void setSelectedFilePath(const boost::filesystem::path& filePath);
+
+	void setAcceptCallback(const std::function<void(const boost::filesystem::path&)>& callback);
+	void setCancelCallback(const std::function<void()>& callback);
+
+private:
+	FileSystemSelectorComponent::Mode m_mode;
+	std::vector<std::string> m_filters;
+	boost::filesystem::path m_currentPath;
+	std::map<boost::filesystem::path, std::vector<FileSystemSelectorComponent::FileEntry>> m_entries;
+	std::shared_ptr<TextComponent> m_currentPathLabel;
+	std::function<void(const boost::filesystem::path&)> m_acceptCallback;
+	std::function<void()> m_cancelCallback;
+
+	void init(const FileSystemSelectorComponent::Mode mode, const boost::filesystem::path& path);
+	std::string titleForCurrentMode() const;
+	FileSystemSelectorComponent::FileEntry::Type filePathType(const boost::filesystem::path& filePath) const;
+	void populate(const boost::filesystem::path& path);
+	std::vector<const FileSystemSelectorComponent::FileEntry*> entriesForCurrentMode() const;
+
+	friend class ModePredicter;
+	friend bool sortPredicter(const FileSystemSelectorComponent::FileEntry&, const FileSystemSelectorComponent::FileEntry&);
+};
+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -15,6 +15,7 @@
 #include "guis/GuiScraperStart.h"
 #include "guis/GuiDetectDevice.h"
 #include "guis/GuiUpdate.h"
+#include "guis/GuiRomsManager.h"
 #include "views/ViewController.h"
 #include "AudioManager.h"
 
@@ -88,6 +89,11 @@ GuiMenu::GuiMenu(Window *window) : GuiComponent(window), mMenu(window, "MAIN MEN
                                                                                              "Shutdown terminated with non-zero result!";
                  });
     }
+    if (Settings::getInstance()->getBool("RomsManager")) {
+		addEntry("ROMS MANAGER", 0x777777FF, true, [this] {
+			mWindow->pushGui(new GuiRomsManager(mWindow));
+		});
+	}
     addEntry("SYSTEM SETTINGS", 0x777777FF, true,
              [this] {
                  Window *window = mWindow;

--- a/es-app/src/guis/GuiRomsManager.cpp
+++ b/es-app/src/guis/GuiRomsManager.cpp
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2015 Filipe Azevedo <pasnox@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+*/
+#include "GuiRomsManager.h"
+#include "views/gamelist/BasicGameListView.h"
+#include "SystemData.h"
+#include "Settings.h"
+#include "Util.h"
+#include "Window.h"
+#include "guis/GuiTextEditPopup.h"
+
+#include "components/FileSystemSelectorComponent.h"
+
+#include <boost/format.hpp>
+#include <boost/system/error_code.hpp>
+
+namespace fs = boost::filesystem;
+
+#define SMALL_FONT_LIGHT Font::get(FONT_SIZE_SMALL, FONT_PATH_LIGHT)
+#define DEFAULT_FONT_COLOR 0x777777FF
+#define DEFAULT_ROMS_PATH_KEY "DefaultRomsPath"
+#define DEFAULT_EXTERNAL_ROMS_PATH_KEY "DefaultExternalRomsPath"
+#define PLATFORM_EXTERNAL_ROMS_PATH_KEY_FORMAT "ExternalRomsPath_%1%"
+#define STRING_SETTING(KEY) Settings::getInstance()->getString(KEY)
+
+namespace {
+	bool fileDataLessThan(const FileData* lhs, const FileData* rhs) {
+		const std::string leftName = strToUpper(lhs->getName());
+		const std::string rightName = strToUpper(rhs->getName());
+
+		if (lhs->getType() == rhs->getType()) {
+			return leftName.compare(rightName) < 0;
+		}
+
+		return lhs->getType() == FOLDER;
+	}
+
+	bool createDirectories(const fs::path& target) {
+		boost::system::error_code ec;
+		fs::create_directories(target, ec);
+		return ec.value() == boost::system::errc::success;
+	}
+
+	bool removeDirectories(const fs::path& target) {
+		boost::system::error_code ec;
+		fs::remove_all(target);
+		return ec.value() == boost::system::errc::success;
+	}
+
+	bool createDirectorySymLink(const fs::path& source, const fs::path& target) {
+		boost::system::error_code ec;
+		fs::create_directory_symlink(source, target, ec);
+		return ec.value() == boost::system::errc::success;
+	}
+
+	bool removeDirectorySymLink(const fs::path& source) {
+		boost::system::error_code ec;
+		fs::remove(source, ec);
+		return ec.value() == boost::system::errc::success;
+	}
+
+	bool createFileSymLink(const fs::path& source, const fs::path& target) {
+		boost::system::error_code ec;
+		fs::create_symlink(source, target, ec);
+		return ec.value() == boost::system::errc::success;
+	}
+
+	bool removeFileSymLink(const fs::path& source) {
+		boost::system::error_code ec;
+		fs::remove(source, ec);
+		return ec.value() == boost::system::errc::success;
+	}
+}
+
+class RomsListView : public BasicGameListView
+{
+private:
+	GuiRomsManager::PlatformData m_data;
+
+public:
+	RomsListView(Window* window, FileData* fileData, const GuiRomsManager::PlatformData& data)
+		: BasicGameListView(window, fileData)
+		, m_data(data)
+	{
+		const fs::path themePath = ThemeData::getThemeFromCurrentSet(m_data.name);
+		auto theme = std::make_shared<ThemeData>();
+
+		try {
+			theme->loadFile(themePath.string());
+		}
+		catch(...) {
+		}
+
+		setTheme(theme);
+
+		mList.setAlignment(mList.ALIGN_LEFT);
+
+		fileData->changePath(m_data.externalRomsPath);
+		fileData->lazyPopulate();
+		fileData->sort(fileDataLessThan, true);
+		populateList(fileData->getChildren());
+	}
+
+	virtual std::vector<HelpPrompt> getHelpPrompts() override {
+		std::vector<HelpPrompt> prompts;
+		prompts.push_back(HelpPrompt("left/right", "link-switch"));
+		prompts.push_back(HelpPrompt("up/down", "move"));
+
+		if (fs::is_directory(getCursor()->getPath())) {
+			prompts.push_back(HelpPrompt("a", "cd in"));
+		}
+
+		prompts.push_back(HelpPrompt("b", "cd up / back"));
+		return prompts;
+	}
+
+	virtual bool input(InputConfig* config, Input input) override {
+		if (config->isMappedTo("up", input) || config->isMappedTo("down", input) || config->isMappedTo("pageup", input) || config->isMappedTo("pagedown", input)) {
+			return BasicGameListView::input(config, input);
+		}
+		else if (input.value != 0) {
+			if (config->isMappedTo("a", input)) {
+				FileData* cursor = getCursor();
+
+				if (cursor->getType() == FOLDER) {
+					if(cursor->getChildren().empty()) {
+						cursor->lazyPopulate();
+						cursor->sort(fileDataLessThan, true);
+					}
+
+					mCursorStack.push(cursor);
+					populateList(cursor->getChildren());
+				}
+			}
+			else if (config->isMappedTo("b", input)) {
+				if (mCursorStack.size()) {
+					populateList(mCursorStack.top()->getParent()->getChildren());
+					setCursor(mCursorStack.top());
+					mCursorStack.pop();
+				}
+				else {
+					onFocusLost();
+					delete this;
+				}
+			}
+			else if (config->isMappedTo("right", input) || config->isMappedTo("left", input)) {
+				// Create / Delete symlink
+				FileData* cursor = getCursor();
+				const int cursorId = mList.getCursor();
+				const fs::path fileName = cursor->getPath().filename();
+				const fs::path platformRomsPath = m_data.romsPath;
+				const fs::path platformRomFilePath = fs::absolute(fileName, platformRomsPath);
+				const bool isSymLink = fs::is_symlink(platformRomFilePath);
+
+				// Don't handle existing non symlink files.
+				if (fs::exists(platformRomFilePath) && !isSymLink) {
+					return true;
+				}
+
+				if (cursor->getType() == GAME) {
+					if (isSymLink) {
+						if (removeFileSymLink(platformRomFilePath)) {
+							updateCursor(cursorId, cursor);
+						}
+					}
+					else {
+						if (createFileSymLink(cursor->getPath(), platformRomFilePath)) {
+							updateCursor(cursorId, cursor);
+						}
+					}
+				}
+				else if (cursor->getType() == FOLDER) {
+					if (isSymLink) {
+						if (removeDirectorySymLink(platformRomFilePath)) {
+							updateCursor(cursorId, cursor);
+						}
+					}
+					else {
+						if (createDirectorySymLink(cursor->getPath(), platformRomFilePath)) {
+							updateCursor(cursorId, cursor);
+						}
+					}
+				}
+			}
+		}
+
+		return true;
+	}
+
+	virtual void populateList(const std::vector<FileData*>& files) override {
+		mList.clear();
+
+		const FileData* root = getRoot();
+		const SystemData* systemData = root->getSystem();
+		const fs::path platformRomsPath = m_data.romsPath;
+
+		mHeaderText.setText(systemData ? systemData->getFullName() : root->getCleanName());
+
+		for (auto it = files.begin(); it != files.end(); it++) {
+			const fs::path fileName = (*it)->getPath().filename();
+			const fs::path platformRomFilePath = fs::absolute(fileName, platformRomsPath);
+			const bool isSymLink = fs::is_symlink(platformRomFilePath);
+			mList.add(formatName((*it)->getName(), isSymLink), *it, ((*it)->getType() == FOLDER));
+		}
+	}
+
+protected:
+	virtual void launch(FileData*) override {
+	}
+
+	std::string formatName(const std::string& name, bool isLinked) const {
+		return str(boost::format("%1% %2%") %(isLinked ? "\u00A4" : "  ") %name);
+	}
+
+	void updateCursor(const int cursorId, FileData* fileData) {
+		const fs::path fileName = fileData->getPath().filename();
+		const fs::path platformRomsPath = m_data.romsPath;
+		const fs::path platformRomFilePath = fs::absolute(fileName, platformRomsPath);
+		const bool isSymLink = fs::is_symlink(platformRomFilePath);
+		mList.changeCursorName(cursorId, formatName(fileData->getName(), isSymLink));
+	}
+};
+
+GuiRomsManager::GuiRomsManager(Window *window)
+	: MenuComponent(window, "ROMS MANAGER")
+	, m_fileData(std::make_shared< FileData >(FOLDER, fs::path(), nullptr))
+	, m_defaultRomsPath(std::make_shared<TextComponent>(window, std::string(), SMALL_FONT_LIGHT, DEFAULT_FONT_COLOR))
+	, m_defaultExternalRomsPath(std::make_shared<TextComponent>(window, std::string(), SMALL_FONT_LIGHT, DEFAULT_FONT_COLOR))
+	, m_platforms(std::make_shared< OptionListComponent<PlatformIds::PlatformId> >(window, "PLATFORM", false))
+	, m_platformExternalRomsPath(std::make_shared<TextComponent>(window, std::string(), SMALL_FONT_LIGHT, DEFAULT_FONT_COLOR))
+	, m_settingsEdited(false)
+{
+	m_defaultRomsPath->setText(STRING_SETTING(DEFAULT_ROMS_PATH_KEY));
+	m_defaultExternalRomsPath->setText(STRING_SETTING(DEFAULT_EXTERNAL_ROMS_PATH_KEY));
+
+	for (int i = PlatformIds::PLATFORM_UNKNOWN +1; i < PlatformIds::PLATFORM_COUNT; ++i) {
+		const PlatformIds::PlatformId id = PlatformIds::PlatformId(i);
+
+		if (id == PlatformIds::PLATFORM_IGNORE) {
+			continue;
+		}
+
+		const std::string platformName = PlatformIds::getPlatformName(id);
+		m_platforms->add(platformName, id, id == PlatformIds::THREEDO);
+	}
+
+	m_platformExternalRomsPath->setText(currentPlatformData().externalRomsPath.string());
+
+	addWithLabel("ROMS", m_defaultRomsPath, true, true, [this](){ editDefaultRomsPath(); });
+	addWithLabel("EXTERNAL ROMS", m_defaultExternalRomsPath, false, true, [this](){ editDefaultExternalRomsPath(); });
+	addWithLabel("PLATFORM", m_platforms);
+	addWithLabel("PLATFORM ROMS", m_platformExternalRomsPath, false, true, [this](){ editCurrentPlatformExternalRomsPath(); });
+
+	m_platforms->setSelectedChangedCallback([this](const PlatformIds::PlatformId&){
+		m_platformExternalRomsPath->setText(currentPlatformData().externalRomsPath.string());
+		onSizeChanged();
+	});
+
+	setSize(Renderer::getScreenWidth() * 0.95f, Renderer::getScreenHeight() * 0.747f);
+	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
+}
+
+GuiRomsManager::~GuiRomsManager()
+{
+	if (m_settingsEdited) {
+		Settings::getInstance()->saveFile();
+	}
+}
+
+bool GuiRomsManager::input(InputConfig* config, Input input)
+{
+	if (config->isMappedTo("x", input) && input.value != 0) {
+		showCurrentPlatformRomsManager();
+		return true;
+	}
+	else if (config->isMappedTo("b", input) && input.value != 0) {
+		delete this;
+		return true;
+	}
+
+	return MenuComponent::input(config, input);
+}
+
+std::vector<HelpPrompt> GuiRomsManager::getHelpPrompts()
+{
+	std::vector<HelpPrompt> prompts = MenuComponent::getHelpPrompts();
+	prompts.push_back(HelpPrompt("x", "manage platform roms"));
+	prompts.push_back(HelpPrompt("a", "edit"));
+	prompts.push_back(HelpPrompt("b", "back"));
+	return prompts;
+}
+
+std::string GuiRomsManager::platformIdExternalRomsKey(PlatformIds::PlatformId platform)
+{
+	const std::string name = PlatformIds::getPlatformName(platform);
+	return str(boost::format(PLATFORM_EXTERNAL_ROMS_PATH_KEY_FORMAT) % name);
+}
+
+fs::path GuiRomsManager::platformIdRomsPath(PlatformIds::PlatformId platform)
+{
+	const std::string path = getExpandedPath(STRING_SETTING(DEFAULT_ROMS_PATH_KEY));
+	const std::string name = PlatformIds::getPlatformName(platform);
+
+	if (!path.empty()) {
+		return fs::absolute(name, path);
+	}
+
+	return fs::path();
+}
+
+fs::path GuiRomsManager::platformIdExternalRomsPath(PlatformIds::PlatformId platform)
+{
+	if (platform == PlatformIds::PLATFORM_UNKNOWN) {
+		return fs::path();
+	}
+
+	const std::string key = platformIdExternalRomsKey(platform);
+	return getExpandedPath(STRING_SETTING(key));
+}
+
+GuiRomsManager::PlatformData GuiRomsManager::currentPlatformData() const
+{
+	PlatformData data;
+	data.id = m_platforms->getSelected();
+	data.name = PlatformIds::getPlatformName(data.id);
+	data.romsPath = platformIdRomsPath(data.id);
+	data.externalRomsPath = platformIdExternalRomsPath(data.id);
+	return data;
+}
+
+void GuiRomsManager::editDefaultRomsPath()
+{
+	const fs::path path = getExpandedPath(STRING_SETTING(DEFAULT_ROMS_PATH_KEY));
+	auto updateValue = [this](const fs::path& filePath) {
+		Settings::getInstance()->setString(DEFAULT_ROMS_PATH_KEY, filePath.string());
+		m_defaultRomsPath->setText(filePath.string());
+		m_settingsEdited = true;
+		onSizeChanged();
+	};
+	auto fileChooser = new FileSystemSelectorComponent(mWindow, path, FileSystemSelectorComponent::FoldersHideFiles);
+	fileChooser->setAcceptCallback(updateValue);
+
+	mWindow->pushGui(fileChooser);
+}
+
+void GuiRomsManager::editDefaultExternalRomsPath()
+{
+	const fs::path path = getExpandedPath(STRING_SETTING(DEFAULT_EXTERNAL_ROMS_PATH_KEY));
+	auto updateValue = [this](const fs::path& filePath) {
+		Settings::getInstance()->setString(DEFAULT_EXTERNAL_ROMS_PATH_KEY, filePath.string());
+		m_defaultExternalRomsPath->setText(filePath.string());
+		m_settingsEdited = true;
+		onSizeChanged();
+	};
+	auto fileChooser = new FileSystemSelectorComponent(mWindow, path, FileSystemSelectorComponent::FoldersHideFiles);
+	fileChooser->setAcceptCallback(updateValue);
+
+	mWindow->pushGui(fileChooser);
+}
+
+void GuiRomsManager::editCurrentPlatformExternalRomsPath()
+{
+	const GuiRomsManager::PlatformData data = currentPlatformData();
+	const std::string key = platformIdExternalRomsKey(data.id);
+	const fs::path defaultPath = getExpandedPath(STRING_SETTING(DEFAULT_EXTERNAL_ROMS_PATH_KEY));
+	const fs::path path = data.externalRomsPath.empty() ? defaultPath : data.externalRomsPath;
+	auto updateValue = [this, key](const fs::path& filePath) {
+		Settings::getInstance()->setString(key, filePath.string());
+		m_platformExternalRomsPath->setText(filePath.string());
+		m_settingsEdited = true;
+		onSizeChanged();
+	};
+	auto fileChooser = new FileSystemSelectorComponent(mWindow, path, FileSystemSelectorComponent::FoldersHideFiles);
+	fileChooser->setAcceptCallback(updateValue);
+
+	mWindow->pushGui(fileChooser);
+}
+
+void GuiRomsManager::showCurrentPlatformRomsManager()
+{
+	const GuiRomsManager::PlatformData data = currentPlatformData();
+
+	if (data.romsPath.empty() || !fs::is_directory(data.externalRomsPath)) {
+		return;
+	}
+
+	if (!fs::exists(data.romsPath)) {
+		if (!createDirectories(data.romsPath)) {
+			return;
+		}
+	}
+
+	mWindow->pushGui(new RomsListView(mWindow, m_fileData.get(), data));
+}

--- a/es-app/src/guis/GuiRomsManager.h
+++ b/es-app/src/guis/GuiRomsManager.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2015 Filipe Azevedo <pasnox@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+*/
+#pragma once
+
+#include "components/MenuComponent.h"
+#include "PlatformId.h"
+#include "components/OptionListComponent.h"
+
+class FileData;
+class RomsListView;
+
+class GuiRomsManager : public MenuComponent
+{
+	friend class RomsListView;
+
+private:
+	struct PlatformData {
+		PlatformIds::PlatformId id;
+		std::string name;
+		boost::filesystem::path romsPath;
+		boost::filesystem::path externalRomsPath;
+	};
+
+public:
+	GuiRomsManager(Window* window);
+	~GuiRomsManager();
+
+	bool input(InputConfig* config, Input input) override;
+	std::vector<HelpPrompt> getHelpPrompts() override;
+
+	static std::string platformIdExternalRomsKey(PlatformIds::PlatformId platform);
+	static boost::filesystem::path platformIdRomsPath(PlatformIds::PlatformId platform);
+	static boost::filesystem::path platformIdExternalRomsPath(PlatformIds::PlatformId platform);
+
+private:
+	std::shared_ptr< FileData > m_fileData;
+	std::shared_ptr<TextComponent> m_defaultRomsPath;
+	std::shared_ptr<TextComponent> m_defaultExternalRomsPath;
+	std::shared_ptr< OptionListComponent<PlatformIds::PlatformId> > m_platforms;
+	std::shared_ptr<TextComponent> m_platformExternalRomsPath;
+	bool m_settingsEdited;
+
+	PlatformData currentPlatformData() const;
+	void editDefaultRomsPath();
+	void editDefaultExternalRomsPath();
+	void editCurrentPlatformExternalRomsPath();
+	void showCurrentPlatformRomsManager();
+};

--- a/es-app/src/guis/GuiSettings.h
+++ b/es-app/src/guis/GuiSettings.h
@@ -19,8 +19,10 @@ public:
 	bool input(InputConfig* config, Input input) override;
 	std::vector<HelpPrompt> getHelpPrompts() override;
 
+	inline MenuComponent *getMenu() const { return &mMenu; }
+
 private:
         bool doSave = true;
-	MenuComponent mMenu;
+	mutable MenuComponent mMenu;
 	std::vector< std::function<void()> > mSaveFuncs;
 };

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -39,7 +39,9 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 {
 	mList.clear();
 
-	mHeaderText.setText(files.at(0)->getSystem()->getFullName());
+	const FileData* root = getRoot();
+	const SystemData* systemData = root->getSystem();
+	mHeaderText.setText(systemData ? systemData->getFullName() : root->getCleanName());
 
 	bool hasFavorites = false;
 

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -27,6 +27,7 @@ public:
 
 	void setTheme(const std::shared_ptr<ThemeData>& theme);
 	inline const std::shared_ptr<ThemeData>& getTheme() const { return mTheme; }
+	inline FileData* getRoot() const { return mRoot; }
 
 	virtual FileData* getCursor() = 0;
 	virtual void setCursor(FileData*) = 0;

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -73,6 +73,20 @@ std::string getCanonicalPath(const std::string& path)
 	return boost::filesystem::canonical(path).generic_string();
 }
 
+std::string getExpandedPath(const std::string& str)
+{
+	std::string path = str;
+
+	//expand home symbol if the startpath contains ~
+	if (!path.empty() && path[0] == '~')
+	{
+		path.erase(0, 1);
+		path.insert(0, getHomePath());
+	}
+
+	return path;
+}
+
 // expands "./my/path.sfc" to "[relativeTo]/my/path.sfc"
 // if allowHome is true, also expands "~/my/path.sfc" to "/home/pi/my/path.sfc"
 fs::path resolvePath(const fs::path& path, const fs::path& relativeTo, bool allowHome)

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -19,6 +19,8 @@ float round(float num);
 
 std::string getCanonicalPath(const std::string& str);
 
+std::string getExpandedPath(const std::string& str);
+
 // example: removeCommonPath("/home/pi/roms/nes/foo/bar.nes", "/home/pi/roms/nes/") returns "foo/bar.nes"
 boost::filesystem::path removeCommonPath(const boost::filesystem::path& path, const boost::filesystem::path& relativeTo, bool& contains);
 

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -11,10 +11,10 @@ ComponentList::ComponentList(Window* window) : IList<ComponentListRow, void*>(wi
 	mFocused = false;
 }
 
-void ComponentList::addRow(const ComponentListRow& row, bool setCursorHere)
+void ComponentList::addRow(const ComponentListRow& row, bool setCursorHere, bool updateGeometry)
 {
 	IList<ComponentListRow, void*>::Entry e;
-	e.name = "";
+	e.name = row.name;
 	e.object = NULL;
 	e.data = row;
 
@@ -23,8 +23,10 @@ void ComponentList::addRow(const ComponentListRow& row, bool setCursorHere)
 	for(auto it = mEntries.back().data.elements.begin(); it != mEntries.back().data.elements.end(); it++)
 		addChild(it->component.get());
 
-	updateElementSize(mEntries.back().data);
-	updateElementPosition(mEntries.back().data);
+	if (updateGeometry) {
+		updateElementSize(mEntries.back().data);
+		updateElementPosition(mEntries.back().data);
+	}
 
 	if(setCursorHere)
 	{

--- a/es-core/src/components/ComponentList.h
+++ b/es-core/src/components/ComponentList.h
@@ -16,12 +16,16 @@ struct ComponentListElement
 struct ComponentListRow
 {
 	std::vector<ComponentListElement> elements;
+	std::string name;
 
 	// The input handler is called when the user enters any input while this row is highlighted (including up/down).
 	// Return false to let the list try to use it or true if the input has been consumed.
 	// If no input handler is supplied (input_handler == nullptr), the default behavior is to forward the input to 
 	// the rightmost element in the currently selected row.
 	std::function<bool(InputConfig*, Input)> input_handler;
+
+	ComponentListRow(const std::string& n = std::string()) : name(n)
+	{}
 	
 	inline void addElement(const std::shared_ptr<GuiComponent>& component, bool resize_width, bool invert_when_selected = true)
 	{
@@ -47,7 +51,7 @@ class ComponentList : public IList<ComponentListRow, void*>
 public:
 	ComponentList(Window* window);
 
-	void addRow(const ComponentListRow& row, bool setCursorHere = false);
+	void addRow(const ComponentListRow& row, bool setCursorHere = false, bool updateGeometry = true);
 
 	void textInput(const char* text) override;
 	bool input(InputConfig* config, Input input) override;

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -147,6 +147,48 @@ public:
 
 		return false;
 	}
+
+	bool setSelectedName(const std::string& name)
+	{
+		for(auto it = mEntries.begin(); it != mEntries.end(); it++)
+		{
+			if((*it).name == name)
+			{
+				mCursor = it - mEntries.begin();
+				onCursorChanged(CURSOR_STOPPED);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool changeCursorName(const UserData& obj, const std::string& name)
+	{
+		for(auto it = mEntries.begin(); it != mEntries.end(); it++)
+		{
+			if((*it).object == obj)
+			{
+				(*it).name = name;
+				(*it).data.textCache.reset();
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool changeCursorName(int cursor, const std::string& name)
+	{
+		if (cursor >= mEntries.size()) {
+			return false;
+		}
+
+		auto& entry = mEntries.at(cursor);
+		entry.name = name;
+		entry.data.textCache.reset();
+		return true;
+	}
 	
 	// entry management
 	void add(const Entry& e)
@@ -169,6 +211,9 @@ public:
 	}
 
 	inline int size() const { return mEntries.size(); }
+
+	inline bool isEmpty() const { return mEntries.empty(); }
+	inline int getCursor() const { return mCursor; }
 
 protected:
 	void remove(typename std::vector<Entry>::iterator& it)

--- a/es-core/src/components/MenuComponent.h
+++ b/es-core/src/components/MenuComponent.h
@@ -21,24 +21,31 @@ public:
 
 	void onSizeChanged() override;
 
-	inline void addRow(const ComponentListRow& row, bool setCursorHere = false) { mList->addRow(row, setCursorHere); updateSize(); }
+	inline void addRow(const ComponentListRow& row, bool setCursorHere = false, bool updateGeometry = true) { mList->addRow(row, setCursorHere, updateGeometry); if (updateGeometry) updateSize(); }
 
-	inline void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, bool setCursorHere = false, bool invert_when_selected = true)
+	inline void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, bool setCursorHere = false, bool invert_when_selected = true, const std::function<void()>& acceptCallback = nullptr)
 	{
 		ComponentListRow row;
 		row.addElement(std::make_shared<TextComponent>(mWindow, strToUpper(label), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
 		row.addElement(comp, false, invert_when_selected);
+		if (acceptCallback) {
+			row.makeAcceptInputHandler(acceptCallback);
+		}
 		addRow(row, setCursorHere);
 	}
 
 	void addButton(const std::string& label, const std::string& helpText, const std::function<void()>& callback);
 
-	void setTitle(const char* title, const std::shared_ptr<Font>& font);
+	void setTitle(const char* title, const std::shared_ptr<Font>& font = Font::get(FONT_SIZE_LARGE));
 
 	inline void setCursorToList() { mGrid.setCursorTo(mList); }
 	inline void setCursorToButtons() { assert(mButtonGrid); mGrid.setCursorTo(mButtonGrid); }
+	inline void clear() { mList->clear(); }
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+
+protected:
+	inline ComponentList* getList() const { return mList.get(); }
 
 private:
 	void updateSize();

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -242,7 +242,7 @@ public:
 		if(selected.size() == 1){
                     return selected.at(0);
                 }else {
-                    return NULL;
+                    return T();
                 }
 	}
         
@@ -267,6 +267,10 @@ public:
 
 		mEntries.push_back(e);
 		onSelectedChanged();
+	}
+
+	inline void setSelectedChangedCallback(const std::function<void(const T&)>& callback) {
+		mSelectedChangedCallback = callback;
 	}
 
 private:
@@ -315,6 +319,10 @@ private:
 				}
 			}
 		}
+
+		if (mSelectedChangedCallback) {
+			mSelectedChangedCallback(mEntries.at(getSelectedId()).object);
+		}
 	}
 
 	std::vector<HelpPrompt> getHelpPrompts() override
@@ -335,4 +343,5 @@ private:
 	ImageComponent mRightArrow;
 
 	std::vector<OptionListData> mEntries;
+	std::function<void(const T&)> mSelectedChangedCallback;
 };

--- a/es-core/src/components/SwitchComponent.cpp
+++ b/es-core/src/components/SwitchComponent.cpp
@@ -5,7 +5,7 @@
 
 SwitchComponent::SwitchComponent(Window* window, bool state) : GuiComponent(window), mImage(window), mState(state)
 {
-	mImage.setImage(":/off.svg");
+	mImage.setImage(mState ? ":/on.svg" : ":/off.svg");
 	mImage.setResize(0, Font::get(FONT_SIZE_MEDIUM)->getLetterHeight());
 	mSize = mImage.getSize();
 }


### PR DESCRIPTION
This is a roms manager that allow to link games (read symlink) from an
external usb device into the system platform roms path.
Meaning you no longer have to copy files on your sd cards or change paths.
Set paths one time (both source and target for each platform), then do symlink.
Add games to your usb device and control what appear in your ES game list!
