### PR TITLE
Fix SDL joystick added flood on OSX

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -251,20 +251,24 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 		break;
 
 	case SDL_JOYDEVICEADDED:
-            if(! getInputConfigByDevice(ev.jdevice.which)){
-                //addJoystickByDeviceIndex(ev.jdevice.which); // ev.jdevice.which is a device index
-                LOG(LogInfo) << "Reinitialize because of SDL_JOYDEVADDED unknown";
-		//addAllJoysticks();
-                this->init();
-            }
-            return true;
+#if defined(__APPLE__)
+        addJoystickByDeviceIndex(ev.jdevice.which); // ev.jdevice.which is a device index
+#else
+        if(! getInputConfigByDevice(ev.jdevice.which)){
+            LOG(LogInfo) << "Reinitialize because of SDL_JOYDEVADDED unknown";
+            this->init();
+        }
+#endif
+        return true;
 
 	case SDL_JOYDEVICEREMOVED:
-		//removeJoystickByJoystickID(ev.jdevice.which); // ev.jdevice.which is an SDL_JoystickID (instance ID)
-                LOG(LogInfo) << "Reinitialize because of SDL_JOYDEVICEREMOVED";
-
-                this->init();
-                return false;
+#if defined(__APPLE__)
+        removeJoystickByJoystickID(ev.jdevice.which); // ev.jdevice.which is an SDL_JoystickID (instance ID)
+#else
+        LOG(LogInfo) << "Reinitialize because of SDL_JOYDEVICEREMOVED";
+        this->init();
+#endif
+        return false;
 	}
 
 	return false;


### PR DESCRIPTION
This is flooding because recalbox ES do deinit / reinit on each joystick added.
This fix flooding to appear.
