### PR TITLE
Default list type : LIST_PAUSE_AT_END

### DIFF
--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -4,7 +4,7 @@
 
 #define TOTAL_HORIZONTAL_PADDING_PX 20
 
-ComponentList::ComponentList(Window* window) : IList<ComponentListRow, void*>(window, LIST_SCROLL_STYLE_SLOW, LIST_NEVER_LOOP)
+ComponentList::ComponentList(Window* window) : IList<ComponentListRow, void*>(window, LIST_SCROLL_STYLE_SLOW, LIST_PAUSE_AT_END)
 {
 	mSelectorBarOffset = 0;
 	mCameraOffset = 0;


### PR DESCRIPTION
Change the default type list to LIST_PAUSE_AT_END
Because to stop your rpi, it's faster to press up to access quit
Because to choose a game, sometimes you want to start from the end, ...

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
