### PR TITLE
Add a refresh entry in the game settings to refresh the games lists w…

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -410,3 +410,9 @@ void SystemData::loadTheme()
 		mTheme = std::make_shared<ThemeData>(); // reset to empty
 	}
 }
+
+void SystemData::refreshRootFolder() {
+  mRootFolder->clear();
+  populateFolder(mRootFolder);
+  mRootFolder->sort(FileSorts::SortTypes.at(0));
+}

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -66,6 +66,9 @@ public:
 	// Load or re-load theme.
 	void loadTheme();
 
+	// refresh the roms files
+	void refreshRootFolder();
+	
 private:
 	std::string mName;
 	std::string mFullName;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -268,6 +268,28 @@ GuiMenu::GuiMenu(Window *window) : GuiComponent(window), mMenu(window, "MAIN MEN
                  rewind_enabled->setState(RecalboxSystem::getInstance()->getRecalboxConfig("global.rewind") == "1");
                  s->addWithLabel("REWIND", rewind_enabled);
 
+		 // reread game list
+		 ComponentListRow row;
+		 Window *window = mWindow;
+		 
+                 row.makeAcceptInputHandler([window] {
+                     window->pushGui(new GuiMsgBox(window, "REALLY UPDATE GAMES LISTS ?", "YES",
+                                                   [] {
+						     // todo : add something nice to display here, in case it takes time ?
+						     for(auto i = SystemData::sSystemVector.begin(); i != SystemData::sSystemVector.end(); i++)
+						       {
+							 (*i)->refreshRootFolder();
+						       }
+
+						     // not sure that all must be reloaded (games lists, lists counters, what else ?)
+						     ViewController::get()->reloadAll();
+						   }, "NO", nullptr));
+                 });
+                 row.addElement(std::make_shared<TextComponent>(window, "UPDATE GAMES LISTS", Font::get(FONT_SIZE_MEDIUM),
+                                                                0x777777FF), true);
+                 s->addRow(row);
+		 
+		 
                  s->addSaveFunc([smoothing_enabled, ratio_choice, rewind_enabled] {
                      RecalboxSystem::getInstance()->setRecalboxConfig("global.smooth", smoothing_enabled->getState() ? "1" : "0");
                      RecalboxSystem::getInstance()->setRecalboxConfig("global.ratio", ratio_choice->getSelected());


### PR DESCRIPTION
…ithout restarting

I don't really like the coding inside the addMenuEntries like this one and the one in shutdown, perhaps, we should add functions :
SystemData::refreshAllRootFolders()
and
GuiMenu::entry_really_updates_games_lists()

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis-lamarre@gmail.com
