### PR TITLE
Decrease the delay time to skip a button

### DIFF
--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -30,7 +30,7 @@ static const char* inputIcon[inputCount] = { ":/help/dpad_up.svg", ":/help/dpad_
 
 using namespace Eigen;
 
-#define HOLD_TO_SKIP_MS 2000
+#define HOLD_TO_SKIP_MS 1000
 
 GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfigureAll, const std::function<void()>& okCallback) : GuiComponent(window), 
 	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 7)), 


### PR DESCRIPTION
Previous delay was 2 seconds, which is cumbersome to wait for a SNES
controller (and possibly other controllers).

The UI that shows the relevant skip action explicitly states to "Hold to
Skip". So the user really doesn't need to wait for the 2 seconds for each button she want to skip.
