### PR TITLE
Don't show empty bar if there is only 1 game

### DIFF
--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -226,8 +226,13 @@ void SystemView::onCursorChanged(const CursorState& state)
 	setAnimation(infoFadeOut, 0, [this, gameCount, favoritesCount] {
 		std::stringstream ss;
 
-		// only display a game count if there are at least 2 games
-		if (gameCount > 1)
+        // show the text even if there is at least 1 game. otherwise it is not
+        // elegant to show a bar appearing with a beautiful animation but there is no text.
+        if (gameCount == 1)
+		{
+			ss << gameCount << boost::locale::gettext(" GAME AVAILABLE");
+		}
+        else if (gameCount > 1)
 		{
 			ss << gameCount << boost::locale::gettext(" GAMES AVAILABLE");
 		}

--- a/locale/lang/de/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/de/LC_MESSAGES/emulationstation2.po
@@ -197,6 +197,9 @@ msgstr "ZURÜCK"
 msgid " GAMES AVAILABLE"
 msgstr " VERFÜGBARE SPIELE"
 
+msgid " GAME AVAILABLE"
+msgstr ""
+
 #: es-app/src/guis/GuiGamelistOptions.cpp
 msgid "JUMP TO LETTER"
 msgstr "SPRING ZU BUCHSTABE"

--- a/locale/lang/es/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/es/LC_MESSAGES/emulationstation2.po
@@ -191,6 +191,9 @@ msgstr "VOLVER"
 msgid " GAMES AVAILABLE"
 msgstr " JUEGOS DISPONIBLES"
 
+msgid " GAME AVAILABLE"
+msgstr ""
+
 #: es-app/src/guis/GuiGamelistOptions.cpp
 msgid "JUMP TO LETTER"
 msgstr "IR A LA LETRA"

--- a/locale/lang/eu_ES/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/eu_ES/LC_MESSAGES/emulationstation2.po
@@ -191,6 +191,9 @@ msgstr "ATZERA EGIN"
 msgid " GAMES AVAILABLE"
 msgstr " JOKU ERABILGARRIAK"
 
+msgid " GAME AVAILABLE"
+msgstr ""
+
 #: es-app/src/guis/GuiGamelistOptions.cpp
 msgid "JUMP TO LETTER"
 msgstr "LETRARA JOAN"

--- a/locale/lang/fr/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/fr/LC_MESSAGES/emulationstation2.po
@@ -191,6 +191,9 @@ msgstr "RETOUR"
 msgid " GAMES AVAILABLE"
 msgstr " JEUX DISPONIBLES"
 
+msgid " GAME AVAILABLE"
+msgstr ""
+
 #: es-app/src/guis/GuiGamelistOptions.cpp
 msgid "JUMP TO LETTER"
 msgstr "ALLER A LA LETTRE"

--- a/locale/lang/it/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/it/LC_MESSAGES/emulationstation2.po
@@ -191,6 +191,9 @@ msgstr "INDIETRO"
 msgid " GAMES AVAILABLE"
 msgstr " GIOCHI DISPONIBILI"
 
+msgid " GAME AVAILABLE"
+msgstr ""
+
 #: es-app/src/guis/GuiGamelistOptions.cpp
 msgid "JUMP TO LETTER"
 msgstr "VAI ALLA LETTERA"

--- a/locale/lang/pt/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/pt/LC_MESSAGES/emulationstation2.po
@@ -191,6 +191,9 @@ msgstr "VOLTAR"
 msgid " GAMES AVAILABLE"
 msgstr " JOGOS DISPONÍVEIS"
 
+msgid " GAME AVAILABLE"
+msgstr ""
+
 #: es-app/src/guis/GuiGamelistOptions.cpp
 msgid "JUMP TO LETTER"
 msgstr "IR PARA A LETRA"


### PR DESCRIPTION
Show the text even if there is at least 1 game. otherwise it is not elegant to show a bar appearing with a beautiful animation but there is no text.

This PR introduces a new string to translate. I applied the new string to all translation files.
