### PR TITLE
Gamelists in roms dir

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -489,21 +489,24 @@ std::string SystemData::getConfigPath(bool forWrite)
 	return "/etc/emulationstation/es_systems.cfg";
 }
 
-std::string SystemData::getGamelistPath(bool forWrite) const
-{
+std::string SystemData::getGamelistPath(bool forWrite) const {
 	fs::path filePath;
 
+	// If we have a gamelist in the rom directory, we use it
 	filePath = mRootFolder->getPath() / "gamelist.xml";
-	if(fs::exists(filePath))
+	if (fs::exists(filePath))
 		return filePath.generic_string();
 
+	// else we try to create it
+	if (forWrite) { // make sure the directory exists if we're going to write to it, or crashes will happen
+		if (fs::exists(filePath.parent_path()) || fs::create_directories(filePath.parent_path())) {
+			return filePath.generic_string();
+		}
+	}
+	// Unable to get or create directory in roms, fallback on ~
 	filePath = getHomePath() + "/.emulationstation/gamelists/" + mName + "/gamelist.xml";
-	if(forWrite) // make sure the directory exists if we're going to write to it, or crashes will happen
-		fs::create_directories(filePath.parent_path());
-	if(forWrite || fs::exists(filePath))
-		return filePath.generic_string();
-
-	return "/etc/emulationstation/gamelists/" + mName + "/gamelist.xml";
+	fs::create_directories(filePath.parent_path());
+	return filePath.generic_string();
 }
 
 std::string SystemData::getThemePath() const

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -274,7 +274,12 @@ std::string getSaveAsPath(const ScraperSearchParams& params, const std::string& 
 	const std::string subdirectory = params.system->getName();
 	const std::string name = params.game->getPath().stem().generic_string() + "-" + suffix;
 
-	std::string path = getHomePath() + "/.emulationstation/downloaded_images/";
+	// default dir in rom directory
+	std::string path = params.system->getRootFolder()->getPath().generic_string() + "/downloaded_images/";
+	if(!boost::filesystem::exists(path) && !boost::filesystem::create_directory(path)){
+		// Unable to create the directory in system rom dir, fallback on ~
+		path = getHomePath() + "/.emulationstation/downloaded_images/";
+	}
 
 	if(!boost::filesystem::exists(path))
 		boost::filesystem::create_directory(path);


### PR DESCRIPTION
For reading gamelists : first read in system rom directories.
For writing gamelists : first try to create in rom directories, fallback in ~ directory if cannot.
For download images : first try to download in rom directories, fallback in ~ directory if cannot.

Already scrapped gamelists : the gamelist will be created in rom directory, but images stays in ~/.emulationstation/downloaded_images
