### PR TITLE
Use locale-aware uppercase functions

### DIFF
--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -1,30 +1,26 @@
 #include "Util.h"
 #include "resources/ResourceManager.h"
 #include "platform.h"
+#include "Locale.h"
 
 namespace fs = boost::filesystem;
 
 std::string strToUpper(const char* from)
 {
 	std::string str(from);
-	for(unsigned int i = 0; i < str.size(); i++) {
-	  str[i] = toupper(from[i]);
-	}
-	return str;
+    return boost::locale::to_upper(str);
 }
 
-std::string& strToUpper(std::string& str)
+std::string& strToUpper(std::string& from)
 {
-  for(unsigned int i = 0; i < str.size(); i++) {
-    str[i] = toupper(str[i]);
-  }
-
-  return str;
+    from = boost::locale::to_upper(from);
+    return from;
 }
 
-std::string strToUpper(const std::string& str)
+std::string strToUpper(const std::string& from)
 {
-	return strToUpper(str.c_str());
+	std::string str(from);
+    return boost::locale::to_upper(str);
 }
 
 


### PR DESCRIPTION
This PR is an attempt to solve the incorrect uppercase operations in EmulationStation for 2+ byte-wide characters, such as "ü" and "ç" in "Türkçe".

Current strToUpper helper functions in Util.cpp source file are very optimistic about the
locale. They assume that each character in a string is 1-byte wide, thus fails to make 2+ byte-wide characters uppercase.

Please see the images below:

This one is from the current state of EmulationStation on Turkish locale. See the lowercase letters. Even though the translation is correct, strToUpper is failed for specific characters.

![tr-locale-incorrect](https://cloud.githubusercontent.com/assets/8654/13031200/edb2bbfe-d2cc-11e5-9f55-c15e3633d305.png)

This is from the applied patch with the correct behaviour:

![tr-locale-correct](https://cloud.githubusercontent.com/assets/8654/13031201/f26a2b46-d2cc-11e5-8b29-da5d4e43f0bb.png)
