### PR TITLE
fixed no music anywhere bug

### DIFF
--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -209,7 +209,7 @@ std::shared_ptr<Music> AudioManager::getRandomMusic(std::string themeSoundDirect
         if (themeSoundDirectory != "") {
             musics = getMusicIn(themeSoundDirectory);
             if(musics.empty()) return NULL;
-        }
+        } else return NULL;
     }
     int randomIndex = rand() % musics.size();
     std::shared_ptr<Music> bgsound = Music::get(musics.at(randomIndex));


### PR DESCRIPTION
fixes es crash when no music is available in the theme folder neither in share/music
