### PR TITLE
Display appropriate buttons in help depending of kind of controller 

### DIFF
--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -8,6 +8,8 @@
 #include "components/ComponentGrid.h"
 #include <boost/assign.hpp>
 
+#include "RecalboxConf.h"
+
 #define OFFSET_X 12 // move the entire thing right by this amount (px)
 #define OFFSET_Y 12 // move the entire thing up by this amount (px)
 
@@ -16,7 +18,7 @@
 
 using namespace Eigen;
 
-static const std::map<std::string, const char*> ICON_PATH_MAP = boost::assign::map_list_of
+static const std::map<std::string, const char*> ICON_PATH_MAP_DEFAULT = boost::assign::map_list_of
 	("up/down", ":/help/dpad_updown.svg")
 	("left/right", ":/help/dpad_leftright.svg")
 	("up/down/left/right", ":/help/dpad_all.svg")
@@ -28,6 +30,19 @@ static const std::map<std::string, const char*> ICON_PATH_MAP = boost::assign::m
 	("r", ":/help/button_r.svg")
 	("start", ":/help/button_start.svg")
 	("select", ":/help/button_select.svg");
+
+static const std::map<std::string, const char*> ICON_PATH_MAP_XBOX = boost::assign::map_list_of
+        ("up/down", ":/help/dpad_updown.svg")
+        ("left/right", ":/help/dpad_leftright.svg")
+        ("up/down/left/right", ":/help/dpad_all.svg")
+        ("a", ":/help/button_b.svg")
+        ("b", ":/help/button_a.svg")
+        ("x", ":/help/button_y.svg")
+        ("y", ":/help/button_x.svg")
+        ("l", ":/help/button_l.svg")
+        ("r", ":/help/button_r.svg")
+        ("start", ":/help/button_start.svg")
+        ("select", ":/help/button_select.svg");
 
 HelpComponent::HelpComponent(Window* window) : GuiComponent(window)
 {
@@ -104,6 +119,10 @@ std::shared_ptr<TextureResource> HelpComponent::getIconTexture(const char* name)
 	auto it = mIconCache.find(name);
 	if(it != mIconCache.end())
 		return it->second;
+
+	std::map<std::string, const char*> ICON_PATH_MAP = ICON_PATH_MAP_DEFAULT;
+	if(RecalboxConf::getInstance()->get("controllers.kind.help") == "xbox")
+		ICON_PATH_MAP = ICON_PATH_MAP_XBOX;
 	
 	auto pathLookup = ICON_PATH_MAP.find(name);
 	if(pathLookup == ICON_PATH_MAP.end())


### PR DESCRIPTION
Not sure this proposition will be accepted but I use it on my instance of recalbox.

When using an XBOX controller type, you have to inverse buttons mapping (A<->B and X<->Y) which is confusing for children in the help of emulationstation.
This modification supports a new property in the recalbox.conf "controllers.kind.help" which defines  how to display buttons in help:
- if not specified or unknown value (default), it is a SNES controller - nothing change from now
- if set to xbox, the A button is displayed instead B, B instead of A, and idem for X / Y

Should be improved to support ps3 (and its geometrical icons) ... 
