### PR TITLE
added raw message from recalbox-upgrade.sh on error

### DIFF
--- a/es-app/src/RecalboxSystem.cpp
+++ b/es-app/src/RecalboxSystem.cpp
@@ -226,13 +226,22 @@ bool RecalboxSystem::setOverclock(std::string mode) {
 }
 
 
-bool RecalboxSystem::updateSystem() {
+std::pair<std::string,int> RecalboxSystem::updateSystem() {
     std::string updatecommand = Settings::getInstance()->getString("UpdateCommand");
-    if (updatecommand.size() > 0) {
-        int exitcode = system(updatecommand.c_str());
-        return exitcode == 0;
+    FILE *pipe = popen(updatecommand.c_str(), "r");
+    char line[1024];
+    if (pipe == NULL) {
+        return std::pair<std::string,int>(std::string("Cannot call update command"),-1);
     }
-    return false;
+    if (fgets(line, 1024, pipe)) {
+        strtok(line, "\n");
+    }
+    int exitCode = pclose(pipe)/256;
+    if(strlen(line) == 0){
+        return std::pair<std::string,int>(std::string("Cannot call update command"), exitCode);
+    }else{
+        return std::pair<std::string,int>(std::string(line), exitCode);
+    }
 }
 
 bool RecalboxSystem::ping() {

--- a/es-app/src/RecalboxSystem.h
+++ b/es-app/src/RecalboxSystem.h
@@ -37,7 +37,7 @@ public:
 
     std::string getVersionMessage();
 
-    bool updateSystem();
+    std::pair<std::string, int> updateSystem();
 
     bool ping();
 

--- a/es-app/src/guis/GuiUpdate.cpp
+++ b/es-app/src/guis/GuiUpdate.cpp
@@ -89,12 +89,11 @@ void GuiUpdate::update(int deltaTime) {
         }
         if(mState == 5){
             window->pushGui(
-			    new GuiMsgBox(window, _("UPDATE FAILED, THE SYSTEM WILL NOW REBOOT"), _("OK"), 
-                [this] {
-                    if(runRestartCommand() != 0) {
-                        LOG(LogWarning) << "Reboot terminated with non-zero result!";
-                    }
-                })
+                    new GuiMsgBox(window, mResult.first, _("OK"),
+                                  [this] {
+                                      mState = -1;
+                                  }
+                    )
             );
             mState = 0;
         }
@@ -113,11 +112,11 @@ void GuiUpdate::update(int deltaTime) {
 
 void GuiUpdate::threadUpdate() 
 {
-    bool updateOk = RecalboxSystem::getInstance()->updateSystem();
-    if(updateOk){
+    std::pair<std::string,int> updateStatus = RecalboxSystem::getInstance()->updateSystem();
+    if(updateStatus.second == 0){
         this->onUpdateOk();
     }else {
-        this->onUpdateError();
+        this->onUpdateError(updateStatus);
     }  
 }
 
@@ -152,10 +151,11 @@ void GuiUpdate::onPingError()
     mLoading = false;
     mState = 3;
 }
-void GuiUpdate::onUpdateError()
+void GuiUpdate::onUpdateError(std::pair<std::string, int> result)
 {
     mLoading = false;
     mState = 5;
+    mResult = result;
 }
 
 void GuiUpdate::onUpdateOk()

--- a/es-app/src/guis/GuiUpdate.h
+++ b/es-app/src/guis/GuiUpdate.h
@@ -25,10 +25,12 @@ private:
     BusyComponent mBusyAnim;
     bool mLoading;
     int mState;
+    std::pair<std::string, int> mResult;
+
     boost::thread *mHandle;
     boost::thread *mPingHandle;
 
-    void onUpdateError();
+    void onUpdateError(std::pair<std::string, int>);
 
     void onUpdateOk();
 
@@ -41,4 +43,5 @@ private:
     void onNoUpdateAvailable();
 
     void onPingError();
+
 };


### PR DESCRIPTION
Provide error message directly from recalbox-upgrade.sh

It's not translated now as it may contains dynamic strings, but as it should not happen often it should be ok.
