### PR TITLE
changed es label for no overclock on rpi1 and zero

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -174,7 +174,7 @@ GuiMenu::GuiMenu(Window *window) : GuiComponent(window), mMenu(window, _("MAIN M
                      overclock_choice->add(_("EXTREM (1100Mhz)"), "extrem", currentOverclock == "extrem");
                      overclock_choice->add(_("TURBO (1000Mhz)"), "turbo", currentOverclock == "turbo");
                      overclock_choice->add(_("HIGH (950Mhz)"), "high", currentOverclock == "high");
-                     overclock_choice->add(_("NONE (700Mhz)"), "none", currentOverclock == "none");
+                     overclock_choice->add(_("NONE"), "none", currentOverclock == "none");
 #elif RPI_VERSION == 2
                      std::string currentOverclock = Settings::getInstance()->getString("Overclock");
                      //overclock_choice->add(_("EXTREM (1100Mhz)"), "rpi2-extrem", currentOverclock == "rpi2-extrem");

--- a/locale/emulationstation2.pot
+++ b/locale/emulationstation2.pot
@@ -170,9 +170,6 @@ msgstr ""
 msgid "HIGH (950Mhz)"
 msgstr ""
 
-msgid "NONE (700Mhz)"
-msgstr ""
-
 msgid "TURBO (1050Mhz)+"
 msgstr ""
 

--- a/locale/lang/de/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/de/LC_MESSAGES/emulationstation2.po
@@ -170,9 +170,6 @@ msgstr "TURBO (1000Mhz)"
 msgid "HIGH (950Mhz)"
 msgstr "HOCH (950Mhz)"
 
-msgid "NONE (700Mhz)"
-msgstr "KEINE (700Mhz)"
-
 msgid "TURBO (1050Mhz)+"
 msgstr "TURBO (1050Mhz)+"
 

--- a/locale/lang/es/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/es/LC_MESSAGES/emulationstation2.po
@@ -171,9 +171,6 @@ msgstr "TURBO (1000Mhz)"
 msgid "HIGH (950Mhz)"
 msgstr "ALTO (950Mhz)"
 
-msgid "NONE (700Mhz)"
-msgstr "NINGUNO (700Mhz)"
-
 msgid "TURBO (1050Mhz)+"
 msgstr "TURBO (1050Mhz)+"
 

--- a/locale/lang/eu_ES/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/eu_ES/LC_MESSAGES/emulationstation2.po
@@ -170,9 +170,6 @@ msgstr "TURBO (1000MHz)"
 msgid "HIGH (950Mhz)"
 msgstr "ALTUA (950Mhz)"
 
-msgid "NONE (700Mhz)"
-msgstr "BAT ERE EZ (700Mhz)"
-
 msgid "TURBO (1050Mhz)+"
 msgstr "TURBO (1050Mhz)+"
 

--- a/locale/lang/fr/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/fr/LC_MESSAGES/emulationstation2.po
@@ -169,9 +169,6 @@ msgstr "TURBO (1000Mhz)"
 msgid "HIGH (950Mhz)"
 msgstr "HIGH (950Mhz)"
 
-msgid "NONE (700Mhz)"
-msgstr "AUCUN (700Mhz)"
-
 msgid "TURBO (1050Mhz)+"
 msgstr "TURBO (1050Mhz)+"
 

--- a/locale/lang/it/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/it/LC_MESSAGES/emulationstation2.po
@@ -172,9 +172,6 @@ msgstr "TURBO (1000Mhz)"
 msgid "HIGH (950Mhz)"
 msgstr "ALTO (950Mhz)"
 
-msgid "NONE (700Mhz)"
-msgstr "NESSUNO (700Mhz)"
-
 msgid "TURBO (1050Mhz)+"
 msgstr "TURBO (1050Mhz)+"
 

--- a/locale/lang/sv_SE/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/sv_SE/LC_MESSAGES/emulationstation2.po
@@ -166,9 +166,6 @@ msgstr ""
 msgid "HIGH (950Mhz)"
 msgstr ""
 
-msgid "NONE (700Mhz)"
-msgstr ""
-
 msgid "TURBO (1050Mhz)+"
 msgstr ""
 

--- a/locale/lang/tr/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/tr/LC_MESSAGES/emulationstation2.po
@@ -170,9 +170,6 @@ msgstr "TURBO (1000Mhz)"
 msgid "HIGH (950Mhz)"
 msgstr "YÜKSEK (950Mhz)"
 
-msgid "NONE (700Mhz)"
-msgstr "YOK (700Mhz)"
-
 msgid "TURBO (1050Mhz)+"
 msgstr "TURBO (1050Mhz)+"
 


### PR DESCRIPTION
Closes https://github.com/recalbox/recalbox-os/issues/1014
