### PR TITLE
configgen: pass to configgen the number of axes of the devices

### DIFF
--- a/es-core/src/InputConfig.cpp
+++ b/es-core/src/InputConfig.cpp
@@ -49,7 +49,7 @@ std::string toLower(std::string str)
 }
 //end util functions
 
-InputConfig::InputConfig(int deviceId, int deviceIndex, const std::string& deviceName, const std::string& deviceGUID) : mDeviceId(deviceId), mDeviceIndex(deviceIndex), mDeviceName(deviceName), mDeviceGUID(deviceGUID)
+InputConfig::InputConfig(int deviceId, int deviceIndex, const std::string& deviceName, const std::string& deviceGUID, int deviceNbAxes) : mDeviceId(deviceId), mDeviceIndex(deviceIndex), mDeviceName(deviceName), mDeviceGUID(deviceGUID), mDeviceNbAxes(deviceNbAxes)
 {
 }
 

--- a/es-core/src/InputConfig.h
+++ b/es-core/src/InputConfig.h
@@ -84,7 +84,7 @@ public:
 class InputConfig
 {
 public:
-	InputConfig(int deviceId, int deviceIndex, const std::string& deviceName, const std::string& deviceGUID);
+	InputConfig(int deviceId, int deviceIndex, const std::string& deviceName, const std::string& deviceGUID, int deviceNbAxes);
 
 	void clear();
 	void mapInput(const std::string& name, Input input);
@@ -95,6 +95,7 @@ public:
 	inline int getDeviceIndex() const { return mDeviceIndex; };
 	inline const std::string& getDeviceName() { return mDeviceName; }
 	inline const std::string& getDeviceGUIDString() { return mDeviceGUID; }
+	inline int getDeviceNbAxes() const { return mDeviceNbAxes; };
 
 	//Returns true if Input is mapped to this name, false otherwise.
 	bool isMappedTo(const std::string& name, Input input);
@@ -117,6 +118,7 @@ private:
 	const int mDeviceIndex;
 	const std::string mDeviceName;
 	const std::string mDeviceGUID;
+	const int mDeviceNbAxes; // number of axes of the device
 };
 
 #endif

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -56,7 +56,7 @@ void InputManager::init()
 	// first, open all currently present joysticks
         this->addAllJoysticks();
 
-	mKeyboardInputConfig = new InputConfig(DEVICE_KEYBOARD, -1, "Keyboard", KEYBOARD_GUID_STRING);
+	mKeyboardInputConfig = new InputConfig(DEVICE_KEYBOARD, -1, "Keyboard", KEYBOARD_GUID_STRING, 0);
 	loadInputConfig(mKeyboardInputConfig);
 }
 
@@ -76,7 +76,7 @@ void InputManager::addJoystickByDeviceIndex(int id)
 	SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(joy), guid, 65);
 
 	// create the InputConfig
-	mInputConfigs[joyId] = new InputConfig(joyId, id, SDL_JoystickName(joy), guid);
+	mInputConfigs[joyId] = new InputConfig(joyId, id, SDL_JoystickName(joy), guid, SDL_JoystickNumAxes(joy));
 	if(!loadInputConfig(mInputConfigs[joyId]))
 	{
 		LOG(LogInfo) << "Added unconfigured joystick " << SDL_JoystickName(joy) << " (GUID: " << guid << ", instance ID: " << joyId << ", device index: " << id << ").";
@@ -540,7 +540,7 @@ std::string InputManager::configureEmulators() {
     for (int player = 0; player < MAX_PLAYERS; player++) {
       InputConfig * playerInputConfig = playerJoysticks[player];
         if(playerInputConfig != NULL){
-            command << "-p" << player+1 << "index " <<  playerInputConfig->getDeviceIndex() << " -p" << player+1 << "guid " << playerInputConfig->getDeviceGUIDString() << " -p" << player+1 << "name \"" <<  playerInputConfig->getDeviceName() << "\" ";
+            command << "-p" << player+1 << "index " <<  playerInputConfig->getDeviceIndex() << " -p" << player+1 << "guid " << playerInputConfig->getDeviceGUIDString() << " -p" << player+1 << "name \"" <<  playerInputConfig->getDeviceName() << "\" -p" << player+1 << "nbaxes " << playerInputConfig->getDeviceNbAxes() << " ";
         }/*else {
             command << " " << "DEFAULT" << " -1 DEFAULTDONOTFINDMEINCOMMAND";
         }*/


### PR DESCRIPTION
linux event handles axes and hats in only one way.
sdl (and probably the old joystick api) separates them in hats and axes.
if you have 2 axes and 1 hat,
dolphin joystick configuration file won't the id of the hat (1 in our case), but
the number of the axes among all axes (3 and 4 because a hat is 2 axes)
in the linux input.h config files, hats are at the end of the axes.
So, a "look like" normal way to compute the dolphin values is to give him the number
of axes (in the sdl sens of axes) of the joystick. It would have been saved in the es_input file,
but it can be computed automatically by es.

note that this break the buildroot compilation while it brakes a es patch.
It will be easier to fix once this commit will be applied.

Signed-off-by: Nicolas Adenis-Lamarre nicolas.adenis.lamarre@gmail.com
