### PR TITLE
POWERSWITCH_REMOTEPI_2015 needs shutdown flags to work correctly

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -454,9 +454,11 @@ int main(int argc, char* argv[])
 	LOG(LogInfo) << "EmulationStation cleanly shutting down.";
 	if (doReboot) {
 		LOG(LogInfo) << "Rebooting system";
+		system("touch /tmp/reboot.please");
 		system("shutdown -r now");
 	} else if (doShutdown) {
 		LOG(LogInfo) << "Shutting system down";
+		system("touch /tmp/shutdown.please");
 		system("shutdown -h now");
 	}
 


### PR DESCRIPTION
Hi,

/tmp/reboot.please and /tmp/shutdown.please have been removed in the following PR :
https://github.com/recalbox/recalbox-emulationstation/pull/131/files

However, the powerswitch.sh script uses these flags to reset REMOTEPIBOARD_2005 hardware state when the shutdown is requested by ES.
Check https://github.com/recalbox/recalbox-emulationstation/pull/131/files Line 125.
/tmp/poweroff.please is the flag set by powerswitch.sh when the shutdown is requested by the hardware.

In a second hand, having an external flag to know which sort of shutdown is requested, can be useful for others scripts during shutdown.
Compilation in progress, tests will follow.

Note :
I made a typo in powerswitch.sh script as in the recalbox.conf, it is not REMOTEPIBOARD_2005, but REMOTEPIBOARD_2015.
In 2005 raspberry didn't exists and so the RemotePi Board. 
Correction will follow, sorry for the inconvenience.

Regards,
