### PR TITLE
added a switch to show hidden files

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -114,6 +114,22 @@ std::vector<FileData*> FileData::getFavoritesRecursive(unsigned int typeMask) co
 	return out;
 }
 
+std::vector<FileData*> FileData::getHiddenRecursive(unsigned int typeMask) const
+{
+	std::vector<FileData*> out;
+	std::vector<FileData*> files = getFilesRecursive(typeMask);
+
+	for (auto it = files.begin(); it != files.end(); it++)
+	{
+		if ((*it)->metadata.get("hidden").compare("true") == 0)
+		{
+			out.push_back(*it);
+		}
+	}
+
+	return out;
+}
+
 void FileData::changePath(const boost::filesystem::path& path)
 {
 	clear();

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -46,6 +46,7 @@ public:
 
 	std::vector<FileData*> getFilesRecursive(unsigned int typeMask) const;
 	std::vector<FileData*> getFavoritesRecursive(unsigned int typeMask) const;
+	std::vector<FileData*> getHiddenRecursive(unsigned int typeMask) const;
 	void changePath(const boost::filesystem::path& path);
 	void addChild(FileData* file); // Error if mType != FOLDER
 	void removeChild(FileData* file); //Error if mType != FOLDER

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -135,10 +135,6 @@ void parseGamelist(SystemData* system)
 			if(file->metadata.get("name").empty())
 				file->metadata.set("name", defaultName);
 			file->metadata.set("system", system->getName());
-
-			if(file->metadata.get("hidden").compare("true") == 0){
-				file->getParent()->removeChild(file);
-			}
 		}
 	}
 }

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -540,6 +540,11 @@ unsigned int SystemData::getFavoritesCount() const
 	return mRootFolder->getFavoritesRecursive(GAME).size();
 }
 
+unsigned int SystemData::getHiddenCount() const
+{
+	return mRootFolder->getHiddenRecursive(GAME).size();
+}
+
 void SystemData::loadTheme()
 {
 	mTheme = std::make_shared<ThemeData>();

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -40,6 +40,7 @@ public:
 	
 	unsigned int getGameCount() const;
 	unsigned int getFavoritesCount() const;
+	unsigned int getHiddenCount() const;
 
 	void launchGame(Window* window, FileData* game);
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -55,6 +55,11 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	mMenu.addWithLabel(_("FAVORITES ONLY"), favorite_only);
 	addSaveFunc([favorite_only] { Settings::getInstance()->setBool("FavoritesOnly", favorite_only->getState()); });
 
+	auto show_hidden = std::make_shared<SwitchComponent>(mWindow);
+	show_hidden->setState(Settings::getInstance()->getBool("ShowHidden"));
+	mMenu.addWithLabel(_("SHOW HIDDEN"), show_hidden);
+	addSaveFunc([show_hidden] { Settings::getInstance()->setBool("ShowHidden", show_hidden->getState()); });
+
 	// edit game metadata
 	row.elements.clear();
 
@@ -71,6 +76,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	mMenu.setPosition((mSize.x() - mMenu.getSize().x()) / 2, (mSize.y() - mMenu.getSize().y()) / 2);
 
 	mFavoriteState = Settings::getInstance()->getBool("FavoritesOnly");
+	mHiddenState = Settings::getInstance()->getBool("ShowHidden");
 }
 
 GuiGamelistOptions::~GuiGamelistOptions()
@@ -82,7 +88,7 @@ GuiGamelistOptions::~GuiGamelistOptions()
 	// notify that the root folder was sorted
 	getGamelist()->onFileChanged(root, FILE_SORTED);
 
-	if (Settings::getInstance()->getBool("FavoritesOnly") != mFavoriteState)
+	if (Settings::getInstance()->getBool("FavoritesOnly") != mFavoriteState || Settings::getInstance()->getBool("ShowHidden") != mHiddenState)
 	{
 		ViewController::get()->setAllInvalidGamesList(getGamelist()->getCursor()->getSystem());
 		ViewController::get()->reloadGameListView(getGamelist()->getCursor()->getSystem());

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -33,8 +33,10 @@ private:
 	std::shared_ptr<SortList> mListSort;
 
 	std::shared_ptr<SwitchComponent> mFavoriteOption;
+	std::shared_ptr<SwitchComponent> mShowHidden;
 
 	bool mFavoriteState;
+	bool mHiddenState;
 	
 	SystemData* mSystem;
 	IGameListView* getGamelist();

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -241,16 +241,27 @@ void SystemView::onCursorChanged(const CursorState& state)
 
 	unsigned int gameCount = getSelected()->getGameCount();
 	unsigned int favoritesCount = getSelected()->getFavoritesCount();
+	unsigned int hiddenCount = getSelected()->getHiddenCount();
+	unsigned int gameNoHiddenCount = gameCount - hiddenCount;
 
 	// also change the text after we've fully faded out
-	setAnimation(infoFadeOut, 0, [this, gameCount, favoritesCount] {
+	setAnimation(infoFadeOut, 0, [this, gameCount, favoritesCount, gameNoHiddenCount, hiddenCount] {
 		char strbuf[256];
-		if(favoritesCount == 0) {
-		  snprintf(strbuf, 256, ngettext("%i GAME AVAILABLE", "%i GAMES AVAILABLE", gameCount).c_str(), gameCount);
-		} else {
-		  snprintf(strbuf, 256,
-			   (ngettext("%i GAME AVAILABLE", "%i GAMES AVAILABLE", gameCount) + ", " +
-			    ngettext("%i FAVORITE", "%i FAVORITES", favoritesCount)).c_str(), gameCount, favoritesCount);
+		if(favoritesCount == 0 && hiddenCount == 0) {
+			snprintf(strbuf, 256, ngettext("%i GAME AVAILABLE", "%i GAMES AVAILABLE", gameNoHiddenCount).c_str(), gameNoHiddenCount);
+		}else if (favoritesCount != 0 && hiddenCount == 0) {
+			snprintf(strbuf, 256,
+				(ngettext("%i GAME AVAILABLE", "%i GAMES AVAILABLE", gameNoHiddenCount) + ", " +
+				 ngettext("%i FAVORITE", "%i FAVORITES", favoritesCount)).c_str(), gameNoHiddenCount, favoritesCount);
+		}else if (favoritesCount == 0 && hiddenCount != 0) {
+			snprintf(strbuf, 256,
+				(ngettext("%i GAME AVAILABLE", "%i GAMES AVAILABLE", gameNoHiddenCount) + ", " +
+				 ngettext("%i GAME HIDDEN", "%i GAMES HIDDEN", hiddenCount)).c_str(), gameNoHiddenCount, hiddenCount);
+		}else {
+			snprintf(strbuf, 256,
+				(ngettext("%i GAME AVAILABLE", "%i GAMES AVAILABLE", gameNoHiddenCount) + ", " +
+				 ngettext("%i GAME HIDDEN", "%i GAMES HIDDEN", hiddenCount) + ", " +
+				 ngettext("%i FAVORITE", "%i FAVORITES", favoritesCount)).c_str(), gameNoHiddenCount, hiddenCount, favoritesCount);
 		}
 		mSystemInfo.setText(strbuf);
 	}, false, 1);

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -46,6 +46,7 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 	mHeaderText.setText(systemData ? systemData->getFullName() : root->getCleanName());
 
 	bool favoritesOnly = false;
+	bool showHidden = Settings::getInstance()->getBool("ShowHidden");
 
 	if (Settings::getInstance()->getBool("FavoritesOnly") && !systemData->isFavorite())
 	{
@@ -68,31 +69,57 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 	if(!Settings::getInstance()->getBool("FavoritesOnly") || systemData->isFavorite()){
 		for(auto it = files.begin(); it != files.end(); it++)
 		{
-			if ((*it)->getType() != FOLDER &&(*it)->metadata.get("favorite").compare("true") == 0)
-			{
-				mList.add("\uF006 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER)); // FIXME Folder as favorite ?
+			if ((*it)->getType() != FOLDER && (*it)->metadata.get("favorite").compare("true") == 0) {
+				if ((*it)->metadata.get("hidden").compare("true") != 0) {
+					mList.add("\uF006 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER)); // FIXME Folder as favorite ?
+				}else {
+					mList.add("\uF006 \uF070 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
+				}
 			}
 		}
 	}
-
+	
 	// Do not show double names in favorite system.
 	if(!systemData->isFavorite())
 	{
 		for (auto it = files.begin(); it != files.end(); it++) {
 			if (favoritesOnly) {
 				if ((*it)->getType() == GAME) {
-					if ((*it)->metadata.get("hidden").compare("yes") != 0) {
-						if ((*it)->metadata.get("favorite").compare("true") == 0) {
-							mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
+					if ((*it)->metadata.get("favorite").compare("true") == 0) {
+						if (!showHidden) {
+							if ((*it)->metadata.get("hidden").compare("true") != 0) {
+								mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
+							}
+						}
+						else {
+							if ((*it)->metadata.get("hidden").compare("true") == 0) {
+								mList.add("\uF070 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
+							}else {
+								mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
+							}
 						}
 					}
 				}
 			}
 			else {
-				if ((*it)->metadata.get("hidden").compare("true") != 0) {
-					if ((*it)->getType() != FOLDER &&(*it)->metadata.get("favorite").compare("true") == 0)
-					{
-						mList.add("\uF006 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
+				if (!showHidden) {
+					if ((*it)->metadata.get("hidden").compare("true") != 0) {
+						if ((*it)->getType() != FOLDER && (*it)->metadata.get("favorite").compare("true") == 0) {
+							mList.add("\uF006 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
+						}else {
+							mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
+						}
+					}
+				}
+				else {
+					if ((*it)->getType() != FOLDER && (*it)->metadata.get("favorite").compare("true") == 0) {
+						if ((*it)->metadata.get("hidden").compare("true") != 0) {
+							mList.add("\uF006 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
+						}else {
+							mList.add("\uF006 \uF070 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
+						}
+					}else if ((*it)->metadata.get("hidden").compare("true") == 0) {
+						mList.add("\uF070 " + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
 					}else {
 						mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
 					}

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -66,6 +66,7 @@ void Settings::setDefaults() {
     mBoolMap["HideConsole"] = true;
     mBoolMap["QuickSystemSelect"] = true;
     mBoolMap["FavoritesOnly"] = false;
+    mBoolMap["ShowHidden"] = false;
 
     mBoolMap["Debug"] = false;
     mBoolMap["DebugGrid"] = false;


### PR DESCRIPTION
Added a switch to show/hide the hidden games in ES.
The switch is located the gamelist options menu.

Once this option activated, if a game is hidden, it will be displayed preceded by this icon : ![alt text](http://image.noelshack.com/fichiers/2016/45/1478791430-eye-closed.jpg "hidden_files")

If a game is in the same time a favorite and a hidden game, it will be displayed preceded by star (as every favorite game) and this new icon.

If the "favorites only" option is activated in the same time, a game as favorite/hidden will be displayed preceded by the new icon. Normal favorites games will be displayed without any icons.

In the system view, the number of hidden games will be displayed for each system. If a game is hidden, it will be removed from the general games counter.

The changelog + .pot files will be updated in a next pull request.
