### PR TITLE
fix bug with small SHARE partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Fix Bug with small SHARE partition
 - Add new Traditional Chinese Language
 - Added Catalan translation
 - Added a virtual keyboard

--- a/es-app/src/RecalboxSystem.cpp
+++ b/es-app/src/RecalboxSystem.cpp
@@ -62,10 +62,14 @@ std::string RecalboxSystem::getFreeSpaceInfo() {
             unsigned long total = (fiData.f_blocks * (fiData.f_bsize / 1024)) / (1024L * 1024L);
             unsigned long free = (fiData.f_bfree * (fiData.f_bsize / 1024)) / (1024L * 1024L);
             unsigned long used = total - free;
-            unsigned long percent = used * 100 / total;
-
+            unsigned long percent = 0;
             std::ostringstream oss;
-            oss << used << "GB/" << total << "GB (" << percent << "%)";
+            if (total != 0){  //for small SD card ;) with share < 1GB
+				percent = used * 100 / total;
+                oss << used << "GB/" << total << "GB (" << percent << "%)";
+			}
+			else
+			    oss << "N/A";
             return oss.str();
         }
     } else {


### PR DESCRIPTION
A small fix to avoid ES quitting with "floating point error" when SHARE partition is less than 1GB