### PR TITLE
Instant Shutdown by only writing changes to gamelist.xml

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -135,6 +135,8 @@ void parseGamelist(SystemData* system)
 			if(file->metadata.get("name").empty())
 				file->metadata.set("name", defaultName);
 			file->metadata.set("system", system->getName());
+			
+			file->metadata.resetChangedFlag();
 		}
 	}
 }
@@ -203,13 +205,23 @@ void updateGamelist(SystemData* system)
 	FileData* rootFolder = system->getRootFolder();
 	if (rootFolder != nullptr)
 	{
+		int numUpdated = 0;
+		
 		//get only files, no folders
 		std::vector<FileData*> files = rootFolder->getFilesRecursive(GAME | FOLDER);
 		//iterate through all files, checking if they're already in the XML
-		std::vector<FileData*>::const_iterator fit = files.cbegin();
-		while(fit != files.cend())
+		for(std::vector<FileData*>::const_iterator fit = files.cbegin(); fit != files.cend(); ++fit)
 		{
 			const char* tag = ((*fit)->getType() == GAME) ? "game" : "folder";
+			
+			// check if current file has metadata, if no, skip it as it wont be in the gamelist anyway.
+			if ((*fit)->metadata.isDefault()) {
+				continue;
+			}
+			
+			// do not touch if it wasn't changed anyway
+			if (!(*fit)->metadata.wasChanged())
+				continue;
 
 			// check if the file already exists in the XML
 			// if it does, remove it before adding
@@ -235,17 +247,21 @@ void updateGamelist(SystemData* system)
 			// it was either removed or never existed to begin with; either way, we can add it now
 			addFileDataNode(root, *fit, tag, system);
 
-			++fit;
+			++numUpdated;
 		}
 
 		//now write the file
 
-		//make sure the folders leading up to this path exist (or the write will fail)
-		boost::filesystem::path xmlWritePath(system->getGamelistPath(true));
-		boost::filesystem::create_directories(xmlWritePath.parent_path());
+		if (numUpdated > 0) {
+			//make sure the folders leading up to this path exist (or the write will fail)
+			boost::filesystem::path xmlWritePath(system->getGamelistPath(true));
+			boost::filesystem::create_directories(xmlWritePath.parent_path());
+			
+			LOG(LogInfo) << "Added/Updated " << numUpdated << " entities in '" << xmlReadPath << "'";
 
-		if (!doc.save_file(xmlWritePath.c_str())) {
-			LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << system->getName() << ")!";
+			if (!doc.save_file(xmlWritePath.c_str())) {
+				LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << system->getName() << ")!";
+			}
 		}
 	}else{
 		LOG(LogError) << "Found no root folder for system \"" << system->getName() << "\"!";

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -57,7 +57,7 @@ const std::vector<MetaDataDecl>& getMDDByType(MetaDataListType type)
 
 
 MetaDataList::MetaDataList(MetaDataListType type)
-	: mType(type)
+	: mType(type), mWasChanged(false)
 {
 	const std::vector<MetaDataDecl>& mdd = getMDD();
 	for(auto iter = mdd.begin(); iter != mdd.end(); iter++)
@@ -117,11 +117,13 @@ void MetaDataList::appendToXML(pugi::xml_node parent, bool ignoreDefaults, const
 void MetaDataList::set(const std::string& key, const std::string& value)
 {
 	mMap[key] = value;
+	mWasChanged = true;
 }
 
 void MetaDataList::setTime(const std::string& key, const boost::posix_time::ptime& time)
 {
 	mMap[key] = boost::posix_time::to_iso_string(time);
+	set(key, boost::posix_time::to_iso_string(time));
 }
 
 const std::string& MetaDataList::get(const std::string& key) const
@@ -142,6 +144,27 @@ float MetaDataList::getFloat(const std::string& key) const
 boost::posix_time::ptime MetaDataList::getTime(const std::string& key) const
 {
 	return string_to_ptime(get(key), "%Y%m%dT%H%M%S%F%q");
+}
+
+bool MetaDataList::isDefault()
+{
+	const std::vector<MetaDataDecl>& mdd = getMDD();
+	
+	for (int i = 1; i < mMap.size(); i++) {
+		if (mMap.at(mdd[i].key) != mdd[i].defaultValue) return false;
+	}
+
+	return true;
+}
+
+bool MetaDataList::wasChanged() const
+{
+	return mWasChanged;
+}
+
+void MetaDataList::resetChangedFlag()
+{
+	mWasChanged = false;
 }
 
 void MetaDataList::merge(const MetaDataList& other) {

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -75,6 +75,11 @@ public:
 	int getInt(const std::string& key) const;
 	float getFloat(const std::string& key) const;
 	boost::posix_time::ptime getTime(const std::string& key) const;
+	
+	bool isDefault();
+	
+	bool wasChanged() const;
+	void resetChangedFlag();
 
 	inline MetaDataListType getType() const { return mType; }
 	inline const std::vector<MetaDataDecl>& getMDD() const { return getMDDByType(getType()); }
@@ -82,4 +87,5 @@ public:
 private:
 	MetaDataListType mType;
 	std::map<std::string, std::string> mMap;
+	bool mWasChanged;
 };


### PR DESCRIPTION
Quoting verybadsoldier: 
"This is a proposal to speedup the shutdown of ES and actually make it shutdown instantly. Usually, ES writes back metadata of all files from all systems to the gamelist.xml. With this PR, ES will keep track of changes to the metadata at runtime and only write back changed entities upon shutdown."

Mix out of:
- https://github.com/RetroPie/EmulationStation/commit/0213bef499dd9e67286c33b56dcf1145cb54e132
- https://github.com/RetroPie/EmulationStation/commit/9ad911c18d8b7e9a769c0f7b09013c63d6202d2e
- https://github.com/RetroPie/EmulationStation/pull/78/commits/44ea23ae6ae8ace74193ebdc0a6e70f7f43b8e10