### PR TITLE
Add sysconfig platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add new special platform ID for custom config scripts (eg. compatibility with retropiemenu)
 - Ignore all known bios and devices for arcade/neogeo platform
 - Fix Bug with small SHARE partition
 - Add new Traditional Chinese Language

--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -227,3 +227,23 @@ EmulationStation where:
   <theme>psp</theme>
 </system>
 ```
+
+## System custom scripts / config
+
+### [sysconfig]
+
+You can create a "gamelist" which contains scripts.
+You could imagine a script wraper to handle .sh .py, and others...
+You could specify "sudo" in &lt;command&gt;, and imagine lot of things.
+As for your games, you can add &lt;image&gt; in your gamelist.xml to add some icons.
+
+``` xml
+<system>
+  <name>myconfig</name>
+  <fullname>Configuration</fullname>
+  <path>/path/to/scripts</path>
+  <extension>.sh</extension>
+  <command>bash %ROM </dev/tty >/dev/tty</command>
+  <platform>sysconfig</platform>
+</system>
+```

--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -76,6 +76,8 @@ namespace PlatformIds
 		"zx81",
 		"moonlight",
 
+		"sysconfig", //Specific external script handler for configuration
+
 		"ignore", // do not allow scraping for this system
 		"invalid"
 	};

--- a/es-app/src/PlatformId.h
+++ b/es-app/src/PlatformId.h
@@ -76,6 +76,8 @@ namespace PlatformIds
 		ZX_81,
 		MOONLIGHT,
 
+		SYSCONFIG, //Specific external script handler for configuration
+
 		PLATFORM_IGNORE, // do not allow scraping for this system
 		PLATFORM_COUNT
 	};

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -479,7 +479,8 @@ GuiMenu::GuiMenu(Window *window) : GuiComponent(window), mMenu(window, _("MAIN M
                              // For each activated system
                              std::vector<SystemData *> systems = SystemData::sSystemVector;
                              for (auto system = systems.begin(); system != systems.end(); system++) {
-                                 if ((*system) != SystemData::getFavoriteSystem()) {
+                                 if ((*system) != SystemData::getFavoriteSystem()
+                                        && !(*system)->hasPlatformId(PlatformIds::SYSCONFIG)) {
                                      ComponentListRow systemRow;
                                      auto systemText = std::make_shared<TextComponent>(mWindow, (*system)->getFullName(),
                                                                                        Font::get(FONT_SIZE_MEDIUM),

--- a/es-app/src/guis/GuiScraperStart.cpp
+++ b/es-app/src/guis/GuiScraperStart.cpp
@@ -25,7 +25,7 @@ GuiScraperStart::GuiScraperStart(Window* window) : GuiComponent(window),
 	mSystems = std::make_shared< OptionListComponent<SystemData*> >(mWindow, _("SCRAPE THESE SYSTEMS"), true);
 	for(auto it = SystemData::sSystemVector.begin(); it != SystemData::sSystemVector.end(); it++)
 	{
-		if(!(*it)->hasPlatformId(PlatformIds::PLATFORM_IGNORE))
+		if(!(*it)->hasPlatformId(PlatformIds::PLATFORM_IGNORE) && !(*it)->hasPlatformId(PlatformIds::SYSCONFIG))
 			mSystems->add((*it)->getFullName(), *it, !(*it)->getPlatformIds().empty());
 	}
 	mMenu.addWithLabel(_("SYSTEMS"), mSystems);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -247,7 +247,9 @@ void SystemView::onCursorChanged(const CursorState& state)
 	// also change the text after we've fully faded out
 	setAnimation(infoFadeOut, 0, [this, gameCount, favoritesCount, gameNoHiddenCount, hiddenCount] {
 		char strbuf[256];
-		if(favoritesCount == 0 && hiddenCount == 0) {
+		if (getSelected()->hasPlatformId(PlatformIds::SYSCONFIG)) {
+			snprintf(strbuf, 256, "%s", _("CONFIGURATION").c_str());
+		}else if(favoritesCount == 0 && hiddenCount == 0) {
 			snprintf(strbuf, 256, ngettext("%i GAME AVAILABLE", "%i GAMES AVAILABLE", gameNoHiddenCount).c_str(), gameNoHiddenCount);
 		}else if (favoritesCount != 0 && hiddenCount == 0) {
 			snprintf(strbuf, 256,


### PR DESCRIPTION
Add sysconfig platform to let user create custom scripts with certain extension in a specified "rom" directory.

Please make sure your PR is ready to be merged !

- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Changes :
- Add a new platform ID called "sysconfig"
- This kind of system is igned from scrapper, and title is "Configuration" instead of "X Games available"
- This kind of system has no "advanced game options"
- User can create a script wraper or exectute script directly, choose wich extentions to use in a specific dir, add icons with his gamelist.xml, etc.

