### PR TITLE
Fix ambiguous function compile error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix : Background musics are now played randomly
 - Added custom favorites icons for each system
 - Only save changed metadata when saving gamelist.xml (improve shutdown time)
+- Fix compile error related to ambiguous function on Linux.
 
 ### Added
 - Favorites as boolean in metadata

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -23,12 +23,13 @@ std::string strToUpper(const std::string& from)
     return boost::locale::to_upper(str);
 }
 
-
+#ifdef _MSC_VER
 #if _MSC_VER < 1800
 float round(float num)
 {
 	return (float)((int)(num + 0.5f));
 }
+#endif
 #endif
 
 Eigen::Affine3f& roundMatrix(Eigen::Affine3f& mat)

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -14,9 +14,11 @@ Eigen::Affine3f roundMatrix(const Eigen::Affine3f& mat);
 
 Eigen::Vector3f roundVector(const Eigen::Vector3f& vec);
 Eigen::Vector2f roundVector(const Eigen::Vector2f& vec);
-
+#ifdef _MSC_VER
+#if _MSC_VER < 1800
 float round(float num);
-
+#endif
+#endif
 std::string getCanonicalPath(const std::string& str);
 
 std::string getExpandedPath(const std::string& str);


### PR DESCRIPTION
This pull request fixes a compile error on Arch Linux... just adds an extra check to make sure _MSC_VER is set before doing the check.

The compile error was as follows:
In file included from ~/Projects/recalbox-emulationstation/es-core/src/components/ImageComponent.cpp:8:0:
~/Projects/recalbox-emulationstation/es-core/src/Util.h:18:22: error: ‘float round(float)’ conflicts with a previous declaration
 float round(float num);

Changes :
- Added ifdef checks to Util.h and Util.cpp
